### PR TITLE
Add `scratch deploy` command for Vercel and Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Now you're ready to start writing in `pages/index.mdx`. Use the `publish` comman
 # Publish your project to a Scratch server.
 # Grant access to specific people, @youdomain.com, or the world
 scratch publish
+
+# Or deploy your built dist/ to a hosting provider
+scratch deploy vercel
+scratch deploy cloudflare
 ```
 
 ## What can you do with Scratch?
@@ -107,6 +111,12 @@ scratch build
 scratch build --no-ssg        # disable static site generation
 scratch build --development   # unminified, with source maps
 
+# Deploy dist/ to external hosting
+scratch deploy vercel          # deploy to Vercel
+scratch deploy cloudflare      # deploy to Cloudflare Pages
+scratch deploy vercel --prod   # production deploy
+scratch deploy cloudflare --project my-site --no-build
+
 # Preview production build locally
 scratch preview
 
@@ -114,9 +124,9 @@ scratch preview
 scratch clean
 
 # Revert a file to its template version
-scratch checkout [file]            # revert a file to its template version
-scratch checkout --force [file]    # overwrite without confirmation
-scratch checkout --list            # list available template files
+scratch eject [file]               # revert a file to its template version
+scratch eject --force [file]       # overwrite without confirmation
+scratch eject --list               # list available template files
 
 # Watch markdown file(s) with live reload
 scratch watch <path>              # file or directory

--- a/cli/src/cmd/deploy/index.ts
+++ b/cli/src/cmd/deploy/index.ts
@@ -1,0 +1,63 @@
+import log, { setLogLevel } from '../../logger';
+import { openBrowser } from '../../util';
+import { getProvider } from './provider-registry';
+import { printDeployResult } from './output';
+import { prepareDeploy } from './preflight';
+import { DeployOptions, DeployProvider, DeployResult } from './types';
+
+interface DeployDependencies {
+  getProvider: (name: string) => DeployProvider;
+  prepareDeploy: typeof prepareDeploy;
+  printDeployResult: typeof printDeployResult;
+  openBrowser: typeof openBrowser;
+  now: () => number;
+}
+
+const defaultDependencies: DeployDependencies = {
+  getProvider,
+  prepareDeploy,
+  printDeployResult,
+  openBrowser,
+  now: () => Date.now(),
+};
+
+export async function deployCommand(
+  providerName: string,
+  projectPath: string = '.',
+  options: DeployOptions = {},
+  deps: DeployDependencies = defaultDependencies
+): Promise<DeployResult> {
+  // Suppress info logs when --json is set so stdout contains only valid JSON.
+  // Errors still appear on stderr via log.error.
+  if (options.json) {
+    setLogLevel('quiet');
+  }
+
+  const provider = deps.getProvider(providerName);
+
+  log.info(`Preparing ${provider.name} deployment...`);
+
+  const ctx = await deps.prepareDeploy(provider.name, projectPath, options);
+
+  await provider.validatePrerequisites(ctx);
+
+  const startedAt = deps.now();
+  const providerResult = await provider.deploy(ctx);
+
+  const duration = deps.now() - startedAt;
+  const result: DeployResult = {
+    provider: provider.name,
+    environment: ctx.environment,
+    project: providerResult.project || ctx.project,
+    url: providerResult.url,
+    duration_ms: duration,
+  };
+
+  deps.printDeployResult(result, Boolean(options.json));
+
+  if (options.open !== false) {
+    await deps.openBrowser(result.url);
+  }
+
+  return result;
+}

--- a/cli/src/cmd/deploy/output.ts
+++ b/cli/src/cmd/deploy/output.ts
@@ -1,0 +1,19 @@
+import log from '../../logger';
+import { DeployResult } from './types';
+
+export function printDeployResult(result: DeployResult, json: boolean): void {
+  if (json) {
+    // Write to stdout directly; log level is set to quiet in --json mode
+    // so this is the only stdout output.
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  log.info('');
+  log.info(`Deploy complete`);
+  log.info(`  provider:    ${result.provider}`);
+  log.info(`  environment: ${result.environment}`);
+  log.info(`  project:     ${result.project}`);
+  log.info(`  url:         ${result.url}`);
+  log.info(`  elapsed:     ${result.duration_ms}ms`);
+}

--- a/cli/src/cmd/deploy/preflight.ts
+++ b/cli/src/cmd/deploy/preflight.ts
@@ -1,0 +1,105 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { BuildContext } from '../../build/context';
+import { buildCommand } from '../build';
+import { confirm, prompt } from '../../util';
+import { DeployEnvironment, DeployOptions, ProviderDeployContext } from './types';
+
+function defaultProjectName(rootDir: string): string {
+  const base = path.basename(rootDir).trim();
+  return base || 'scratch-site';
+}
+
+export function resolveEnvironment(options: DeployOptions): DeployEnvironment {
+  if (options.prod && options.preview) {
+    throw new Error('Choose either --prod or --preview, not both.');
+  }
+  return options.prod ? 'prod' : 'preview';
+}
+
+export function resolveRootDir(projectPath: string): string {
+  return path.resolve(projectPath || '.');
+}
+
+export async function resolveProjectName(rootDir: string, options: DeployOptions): Promise<string> {
+  if (options.project?.trim()) return options.project.trim();
+
+  const fallback = defaultProjectName(rootDir);
+  const nonInteractive = options.yes || options.json || !process.stdin.isTTY;
+  if (nonInteractive) {
+    return fallback;
+  }
+
+  return await prompt('Project name', fallback);
+}
+
+export async function maybeConfirmDeploy(options: DeployOptions, provider: string, project: string, environment: DeployEnvironment): Promise<void> {
+  const nonInteractive = options.yes || options.json || !process.stdin.isTTY;
+  if (nonInteractive) return;
+
+  const approved = await confirm(
+    `Deploy dist/ to ${provider} project "${project}" (${environment})?`,
+    true
+  );
+
+  if (!approved) {
+    throw new Error('Deploy cancelled by user.');
+  }
+}
+
+export async function runBuildIfNeeded(rootDir: string, options: DeployOptions): Promise<void> {
+  if (options.noBuild) return;
+
+  // Use base: '' for external hosting providers (Vercel, Cloudflare Pages)
+  // where sites are served from root. Users needing a custom base can
+  // run `scratch build --base /path/` separately and deploy with --no-build.
+  const buildCtx = new BuildContext({
+    path: rootDir,
+    base: '',
+  });
+
+  await buildCommand(buildCtx, { ssg: true }, rootDir);
+}
+
+export async function ensureDistDir(rootDir: string): Promise<string> {
+  const distDir = path.join(rootDir, 'dist');
+
+  try {
+    const stat = await fs.stat(distDir);
+    if (!stat.isDirectory()) {
+      throw new Error('dist/ exists but is not a directory.');
+    }
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      throw new Error('dist/ directory not found. Run `scratch build` first or omit --no-build.');
+    }
+    throw error;
+  }
+
+  return distDir;
+}
+
+export async function prepareDeploy(provider: string, projectPath: string, options: DeployOptions): Promise<ProviderDeployContext> {
+  const rootDir = resolveRootDir(projectPath);
+  const environment = resolveEnvironment(options);
+  const project = await resolveProjectName(rootDir, options);
+
+  if (!project) {
+    throw new Error('Project name cannot be empty. Use --project <name>.');
+  }
+
+  await maybeConfirmDeploy(options, provider, project, environment);
+  await runBuildIfNeeded(rootDir, options);
+
+  const distDir = await ensureDistDir(rootDir);
+  const nonInteractive = Boolean(options.yes || options.json || !process.stdin.isTTY);
+
+  return {
+    rootDir,
+    distDir,
+    environment,
+    project,
+    org: options.org,
+    nonInteractive,
+  };
+}

--- a/cli/src/cmd/deploy/provider-registry.ts
+++ b/cli/src/cmd/deploy/provider-registry.ts
@@ -1,0 +1,28 @@
+import { cloudflareProvider } from './providers/cloudflare';
+import { vercelProvider } from './providers/vercel';
+import { DeployProvider, DeployProviderName } from './types';
+
+const PROVIDERS: Record<DeployProviderName, DeployProvider> = {
+  vercel: vercelProvider,
+  cloudflare: cloudflareProvider,
+};
+
+export function listProviders(): DeployProviderName[] {
+  return Object.keys(PROVIDERS) as DeployProviderName[];
+}
+
+export function getProvider(name: string): DeployProvider {
+  const normalized = name.toLowerCase();
+
+  if (normalized === 'cloudflare-pages' || normalized === 'cf') {
+    return PROVIDERS.cloudflare;
+  }
+
+  if (normalized in PROVIDERS) {
+    return PROVIDERS[normalized as DeployProviderName];
+  }
+
+  throw new Error(
+    `Unsupported provider: ${name}. Supported providers: ${listProviders().join(', ')}`
+  );
+}

--- a/cli/src/cmd/deploy/providers/cloudflare.ts
+++ b/cli/src/cmd/deploy/providers/cloudflare.ts
@@ -1,0 +1,87 @@
+import { ensureAuthenticated, ensureToolAvailable } from '../utils/auth';
+import { runCommand } from '../utils/spawn';
+import { ensureHttpsUrl, pickDeployUrl } from '../utils/url';
+import { DeployProvider, ProviderDeployContext } from '../types';
+
+function buildAccountArgs(org?: string): string[] {
+  return org ? ['--account-id', org] : [];
+}
+
+async function getGitBranch(rootDir: string): Promise<string | null> {
+  const result = await runCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: rootDir,
+    allowFailure: true,
+  });
+
+  if (result.exitCode !== 0) return null;
+  const branch = result.stdout.trim();
+  if (!branch || branch === 'HEAD') return null;
+  return branch;
+}
+
+async function getCloudflareProductionBranch(ctx: ProviderDeployContext): Promise<string | null> {
+  const result = await runCommand(
+    'wrangler',
+    ['pages', 'project', 'list', '--json', ...buildAccountArgs(ctx.org)],
+    { cwd: ctx.rootDir, allowFailure: true }
+  );
+
+  if (result.exitCode !== 0 || !result.stdout.trim()) {
+    return null;
+  }
+
+  try {
+    const projects = JSON.parse(result.stdout) as Array<{ name?: string; production_branch?: string }>;
+    const project = projects.find((entry) => entry.name === ctx.project);
+    return project?.production_branch || null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveDeployBranch(ctx: ProviderDeployContext): Promise<string> {
+  if (ctx.environment === 'preview') {
+    return (await getGitBranch(ctx.rootDir)) || 'preview';
+  }
+
+  return (await getCloudflareProductionBranch(ctx)) || 'main';
+}
+
+export const cloudflareProvider: DeployProvider = {
+  name: 'cloudflare',
+  description: 'Deploy dist/ to Cloudflare Pages',
+
+  async validatePrerequisites(): Promise<void> {
+    await ensureToolAvailable('wrangler', 'Install it with: npm i -g wrangler');
+    await ensureAuthenticated('wrangler', ['whoami'], 'Run `wrangler login` and try again.');
+  },
+
+  async deploy(ctx) {
+    const branch = await resolveDeployBranch(ctx);
+
+    const args = [
+      'pages',
+      'deploy',
+      ctx.distDir,
+      '--project-name',
+      ctx.project,
+      '--branch',
+      branch,
+      ...buildAccountArgs(ctx.org),
+    ];
+
+    const result = await runCommand('wrangler', args, { cwd: ctx.rootDir });
+    const combinedOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+    const rawUrl = pickDeployUrl(combinedOutput, 'cloudflare');
+
+    if (!rawUrl) {
+      throw new Error('Cloudflare deploy succeeded but no deploy URL was detected in output.');
+    }
+
+    return {
+      project: ctx.project,
+      url: ensureHttpsUrl(rawUrl),
+      rawOutput: combinedOutput,
+    };
+  },
+};

--- a/cli/src/cmd/deploy/providers/vercel.ts
+++ b/cli/src/cmd/deploy/providers/vercel.ts
@@ -1,0 +1,54 @@
+import { ensureAuthenticated, ensureToolAvailable } from '../utils/auth';
+import { runCommand } from '../utils/spawn';
+import { ensureHttpsUrl, pickDeployUrl } from '../utils/url';
+import { DeployProvider, ProviderDeployContext } from '../types';
+
+function buildScopeArgs(ctx: ProviderDeployContext): string[] {
+  return ctx.org ? ['--scope', ctx.org] : [];
+}
+
+async function ensureProjectLinked(ctx: ProviderDeployContext): Promise<void> {
+  const args = ['link', '--project', ctx.project, ...buildScopeArgs(ctx)];
+  if (ctx.nonInteractive) {
+    args.push('--yes');
+  }
+  await runCommand('vercel', args, { cwd: ctx.rootDir });
+}
+
+export const vercelProvider: DeployProvider = {
+  name: 'vercel',
+  description: 'Deploy dist/ to Vercel',
+
+  async validatePrerequisites(): Promise<void> {
+    await ensureToolAvailable('vercel', 'Install it with: npm i -g vercel');
+    await ensureAuthenticated('vercel', ['whoami'], 'Run `vercel login` and try again.');
+  },
+
+  async deploy(ctx) {
+    await ensureProjectLinked(ctx);
+
+    const args = ['deploy', ctx.distDir, ...buildScopeArgs(ctx)];
+
+    if (ctx.environment === 'prod') {
+      args.push('--prod');
+    }
+
+    if (ctx.nonInteractive) {
+      args.push('--yes');
+    }
+
+    const result = await runCommand('vercel', args, { cwd: ctx.rootDir });
+    const combinedOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+    const rawUrl = pickDeployUrl(combinedOutput, 'vercel');
+
+    if (!rawUrl) {
+      throw new Error('Vercel deploy succeeded but no deploy URL was detected in output.');
+    }
+
+    return {
+      project: ctx.project,
+      url: ensureHttpsUrl(rawUrl),
+      rawOutput: combinedOutput,
+    };
+  },
+};

--- a/cli/src/cmd/deploy/types.ts
+++ b/cli/src/cmd/deploy/types.ts
@@ -1,0 +1,43 @@
+export type DeployProviderName = 'vercel' | 'cloudflare';
+export type DeployEnvironment = 'preview' | 'prod';
+
+export interface DeployOptions {
+  prod?: boolean;
+  preview?: boolean;
+  project?: string;
+  org?: string;
+  yes?: boolean;
+  noBuild?: boolean;
+  open?: boolean;
+  json?: boolean;
+}
+
+export interface DeployResult {
+  provider: DeployProviderName;
+  environment: DeployEnvironment;
+  project: string;
+  url: string;
+  duration_ms: number;
+}
+
+export interface ProviderDeployContext {
+  rootDir: string;
+  distDir: string;
+  environment: DeployEnvironment;
+  project: string;
+  org?: string;
+  nonInteractive: boolean;
+}
+
+export interface ProviderDeployResult {
+  project?: string;
+  url: string;
+  rawOutput?: string;
+}
+
+export interface DeployProvider {
+  name: DeployProviderName;
+  description: string;
+  validatePrerequisites: (ctx: ProviderDeployContext) => Promise<void>;
+  deploy: (ctx: ProviderDeployContext) => Promise<ProviderDeployResult>;
+}

--- a/cli/src/cmd/deploy/utils/auth.ts
+++ b/cli/src/cmd/deploy/utils/auth.ts
@@ -1,0 +1,27 @@
+import { CommandError, runCommand } from './spawn';
+
+export async function ensureToolAvailable(tool: string, installHint: string): Promise<void> {
+  try {
+    await runCommand(tool, ['--version']);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Command not found')) {
+      throw new Error(`${tool} is required but was not found. ${installHint}`);
+    }
+    throw error;
+  }
+}
+
+export async function ensureAuthenticated(
+  tool: string,
+  args: string[],
+  loginHint: string
+): Promise<void> {
+  try {
+    await runCommand(tool, args);
+  } catch (error) {
+    if (error instanceof CommandError) {
+      throw new Error(`Authentication check failed for ${tool}. ${loginHint}`);
+    }
+    throw error;
+  }
+}

--- a/cli/src/cmd/deploy/utils/spawn.ts
+++ b/cli/src/cmd/deploy/utils/spawn.ts
@@ -1,0 +1,78 @@
+export interface RunCommandOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  allowFailure?: boolean;
+}
+
+export interface RunCommandResult {
+  command: string;
+  args: string[];
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export class CommandError extends Error {
+  result: RunCommandResult;
+
+  constructor(message: string, result: RunCommandResult) {
+    super(message);
+    this.name = 'CommandError';
+    this.result = result;
+  }
+}
+
+function decodeOutput(data: Uint8Array | null): string {
+  if (!data) return '';
+  return new TextDecoder().decode(data).trim();
+}
+
+export async function runCommand(command: string, args: string[], options: RunCommandOptions = {}): Promise<RunCommandResult> {
+  const exePath = Bun.which(command);
+  if (!exePath) {
+    throw new Error(`Command not found: ${command}`);
+  }
+
+  const mergedEnv = {
+    ...process.env,
+    ...(options.env || {}),
+  };
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(mergedEnv)) {
+    if (typeof value === 'string') {
+      env[key] = value;
+    }
+  }
+
+  const proc = Bun.spawn([exePath, ...args], {
+    cwd: options.cwd,
+    env,
+    stdin: 'inherit',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdoutBuffer, stderrBuffer, exitCode] = await Promise.all([
+    proc.stdout ? new Response(proc.stdout).arrayBuffer() : new ArrayBuffer(0),
+    proc.stderr ? new Response(proc.stderr).arrayBuffer() : new ArrayBuffer(0),
+    proc.exited,
+  ]);
+
+  const result: RunCommandResult = {
+    command,
+    args,
+    exitCode,
+    stdout: decodeOutput(new Uint8Array(stdoutBuffer)),
+    stderr: decodeOutput(new Uint8Array(stderrBuffer)),
+  };
+
+  if (exitCode !== 0 && !options.allowFailure) {
+    const details = [result.stderr, result.stdout].filter(Boolean).join('\n');
+    throw new CommandError(
+      `Command failed: ${command} ${args.join(' ')}${details ? `\n${details}` : ''}`,
+      result
+    );
+  }
+
+  return result;
+}

--- a/cli/src/cmd/deploy/utils/url.ts
+++ b/cli/src/cmd/deploy/utils/url.ts
@@ -1,0 +1,42 @@
+const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/g;
+
+export function extractUrls(text: string): string[] {
+  if (!text) return [];
+  return text.match(URL_PATTERN) || [];
+}
+
+export function pickDeployUrl(text: string, provider: 'vercel' | 'cloudflare'): string | null {
+  const urls = extractUrls(text);
+  if (urls.length === 0) return null;
+
+  if (provider === 'vercel') {
+    const vercelUrl = urls.find((url) => /\.vercel\.app\/?$/.test(url));
+    if (vercelUrl) return sanitizeUrl(vercelUrl);
+  }
+
+  if (provider === 'cloudflare') {
+    const pagesUrl = urls.find((url) => /\.pages\.dev\/?$/.test(url));
+    if (pagesUrl) return sanitizeUrl(pagesUrl);
+  }
+
+  return sanitizeUrl(urls[0]!);
+}
+
+export function sanitizeUrl(url: string): string {
+  return url.replace(/[),.;]+$/, '');
+}
+
+export function ensureHttpsUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Could not parse deploy URL: ${url}`);
+  }
+
+  if (!['https:', 'http:'].includes(parsed.protocol)) {
+    throw new Error(`Unsupported URL protocol: ${parsed.protocol}`);
+  }
+
+  return sanitizeUrl(parsed.toString());
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,6 +9,7 @@ import { previewCommand } from './cmd/preview';
 import { checkoutCommand } from './cmd/checkout';
 import { updateCommand } from './cmd/update';
 import { watchCommand } from './cmd/watch';
+import { deployCommand } from './cmd/deploy';
 import { BuildContext } from './build/context';
 import log, { setLogLevel, setShowBunErrors, shouldShowBunErrors } from './logger';
 import { VERSION } from './version';
@@ -102,6 +103,34 @@ program
       } else {
         log.info(`Build completed in ${elapsed}ms`);
       }
+    })
+  );
+
+program
+  .command('deploy')
+  .description('Deploy dist/ to an external provider')
+  .argument('<provider>', 'Provider name (vercel, cloudflare)')
+  .argument('[path]', 'Path to project directory', '.')
+  .option('--prod', 'Deploy to production target')
+  .option('--preview', 'Force preview deployment (default)')
+  .option('--project <name>', 'Provider project name')
+  .option('--org <name>', 'Provider org/team/account identifier')
+  .option('--yes', 'Skip confirmation prompts')
+  .option('--no-build', 'Skip build step')
+  .option('--no-open', "Don't open browser after deploy")
+  .option('--json', 'Output machine-readable JSON')
+  .action(
+    withErrorHandling('Deploy', async (provider, projectPath, options) => {
+      await deployCommand(provider, projectPath, {
+        prod: options.prod === true,
+        preview: options.preview === true,
+        project: options.project,
+        org: options.org,
+        yes: options.yes === true,
+        noBuild: options.build === false,
+        open: options.open !== false,
+        json: options.json === true,
+      });
     })
   );
 
@@ -430,7 +459,7 @@ program
 // Command groups with ordering - single source of truth
 // Commands appear in help in the order listed here
 const COMMAND_GROUPS_CONFIG = [
-  { name: 'Local', commands: ['create', 'dev', 'build', 'preview', 'watch', 'clean', 'eject', 'config'] },
+  { name: 'Local', commands: ['create', 'dev', 'build', 'deploy', 'preview', 'watch', 'clean', 'eject', 'config'] },
   { name: 'Server', commands: ['publish', 'login', 'logout', 'whoami', 'projects', 'share', 'tokens', 'cf-access', 'set-defaults'] },
   { name: 'Other', commands: ['update', 'help'] },
 ] as const;

--- a/cli/test/e2e/deploy-command.test.ts
+++ b/cli/test/e2e/deploy-command.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { runCliCapture } from './util';
+
+describe('deploy command help', () => {
+  test('top-level help includes deploy command', () => {
+    const result = runCliCapture(['--help'], '.');
+    expect(result.stdout).toContain('deploy');
+    expect(result.stdout).toContain('Deploy dist/ to an external provider');
+  });
+
+  test('deploy help shows provider argument', () => {
+    const result = runCliCapture(['deploy', '--help'], '.');
+    expect(result.stdout).toContain('<provider>');
+    expect(result.stdout).toContain('Provider name (vercel, cloudflare)');
+  });
+
+  test('deploy help shows all expected flags', () => {
+    const result = runCliCapture(['deploy', 'vercel', '--help'], '.');
+    expect(result.stdout).toContain('--prod');
+    expect(result.stdout).toContain('--preview');
+    expect(result.stdout).toContain('--project <name>');
+    expect(result.stdout).toContain('--org <name>');
+    expect(result.stdout).toContain('--yes');
+    expect(result.stdout).toContain('--no-build');
+    expect(result.stdout).toContain('--no-open');
+    expect(result.stdout).toContain('--json');
+  });
+});

--- a/cli/test/unit/deploy/index.test.ts
+++ b/cli/test/unit/deploy/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { deployCommand } from '../../../src/cmd/deploy';
+import { DeployProvider, ProviderDeployContext } from '../../../src/cmd/deploy/types';
+
+describe('deployCommand', () => {
+  function createContext(overrides: Partial<ProviderDeployContext> = {}): ProviderDeployContext {
+    return {
+      rootDir: '/tmp/site',
+      distDir: '/tmp/site/dist',
+      environment: 'preview',
+      project: 'my-site',
+      org: undefined,
+      nonInteractive: true,
+      ...overrides,
+    };
+  }
+
+  function createProvider(): DeployProvider {
+    return {
+      name: 'vercel',
+      description: 'Deploy to Vercel',
+      validatePrerequisites: async () => {},
+      deploy: async () => ({
+        project: 'my-site',
+        url: 'https://my-site.vercel.app',
+      }),
+    };
+  }
+
+  test('returns deploy result and opens browser by default', async () => {
+    let openedUrl: string | null = null;
+    let printed = false;
+
+    const result = await deployCommand('vercel', '.', {}, {
+      getProvider: () => createProvider(),
+      prepareDeploy: async () => createContext(),
+      printDeployResult: () => {
+        printed = true;
+      },
+      openBrowser: async (url: string) => {
+        openedUrl = url;
+      },
+      now: (() => {
+        let calls = 0;
+        return () => (calls++ === 0 ? 100 : 250);
+      })(),
+    });
+
+    expect(result.provider).toBe('vercel');
+    expect(result.environment).toBe('preview');
+    expect(result.project).toBe('my-site');
+    expect(result.url).toBe('https://my-site.vercel.app');
+    expect(result.duration_ms).toBe(150);
+    expect(printed).toBe(true);
+    expect(openedUrl).toBe('https://my-site.vercel.app');
+  });
+
+  test('skips browser open when --no-open is set', async () => {
+    let opened = false;
+
+    await deployCommand('vercel', '.', { open: false }, {
+      getProvider: () => createProvider(),
+      prepareDeploy: async () => createContext({ environment: 'prod' }),
+      printDeployResult: () => {},
+      openBrowser: async () => {
+        opened = true;
+      },
+      now: (() => {
+        let calls = 0;
+        return () => (calls++ === 0 ? 0 : 10);
+      })(),
+    });
+
+    expect(opened).toBe(false);
+  });
+});

--- a/cli/test/unit/deploy/output.test.ts
+++ b/cli/test/unit/deploy/output.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import { printDeployResult } from '../../../src/cmd/deploy/output';
+
+describe('deploy output', () => {
+  let logSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    logSpy?.mockRestore();
+  });
+
+  test('prints JSON output when requested', () => {
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+    printDeployResult(
+      {
+        provider: 'vercel',
+        environment: 'preview',
+        project: 'my-site',
+        url: 'https://my-site.vercel.app',
+        duration_ms: 1234,
+      },
+      true
+    );
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const firstCall = logSpy.mock.calls[0]?.[0] as string;
+    expect(firstCall).toContain('"provider": "vercel"');
+    expect(firstCall).toContain('"duration_ms": 1234');
+  });
+
+  test('prints human-readable output when json is false', () => {
+    const lines: string[] = [];
+    logSpy = spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    });
+
+    printDeployResult(
+      {
+        provider: 'cloudflare',
+        environment: 'prod',
+        project: 'docs-site',
+        url: 'https://docs-site.pages.dev',
+        duration_ms: 5678,
+      },
+      false
+    );
+
+    const output = lines.join('\n');
+    expect(output).toContain('Deploy complete');
+    expect(output).toContain('cloudflare');
+    expect(output).toContain('prod');
+    expect(output).toContain('docs-site');
+    expect(output).toContain('https://docs-site.pages.dev');
+    expect(output).toContain('5678ms');
+  });
+});

--- a/cli/test/unit/deploy/preflight.test.ts
+++ b/cli/test/unit/deploy/preflight.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'fs/promises';
+import path from 'path';
+import { mkTempDir } from '../../test-util';
+import { ensureDistDir, resolveEnvironment, resolveProjectName, resolveRootDir } from '../../../src/cmd/deploy/preflight';
+
+describe('deploy preflight', () => {
+  test('resolveEnvironment defaults to preview', () => {
+    expect(resolveEnvironment({})).toBe('preview');
+    expect(resolveEnvironment({ prod: true })).toBe('prod');
+  });
+
+  test('resolveEnvironment rejects conflicting flags', () => {
+    expect(() => resolveEnvironment({ prod: true, preview: true })).toThrow(/Choose either --prod or --preview/);
+  });
+
+  test('resolveRootDir returns an absolute path', () => {
+    expect(path.isAbsolute(resolveRootDir('.'))).toBe(true);
+  });
+
+  test('resolveProjectName uses explicit project when provided', async () => {
+    const name = await resolveProjectName('/tmp/test', { project: 'my-site' });
+    expect(name).toBe('my-site');
+  });
+
+  test('resolveProjectName falls back to directory name for non-interactive mode', async () => {
+    const name = await resolveProjectName('/tmp/example-site', { yes: true });
+    expect(name).toBe('example-site');
+  });
+
+  test('ensureDistDir accepts existing dist directory', async () => {
+    const tempDir = await mkTempDir('deploy-preflight-');
+    try {
+      await fs.mkdir(path.join(tempDir, 'dist'), { recursive: true });
+      const dist = await ensureDistDir(tempDir);
+      expect(dist).toBe(path.join(tempDir, 'dist'));
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('ensureDistDir throws when dist is missing', async () => {
+    const tempDir = await mkTempDir('deploy-preflight-');
+    try {
+      await expect(ensureDistDir(tempDir)).rejects.toThrow(/dist\/ directory not found/);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('resolveProjectName trims whitespace from explicit name', async () => {
+    const name = await resolveProjectName('/tmp/test', { project: '  my-site  ' });
+    expect(name).toBe('my-site');
+  });
+
+  test('resolveProjectName falls back to scratch-site for root path', async () => {
+    const name = await resolveProjectName('/', { yes: true });
+    expect(name).toBe('scratch-site');
+  });
+
+  test('resolveRootDir resolves relative paths', () => {
+    const result = resolveRootDir('some/relative/path');
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).toContain('some/relative/path');
+  });
+
+  test('resolveRootDir defaults to cwd for empty string', () => {
+    const result = resolveRootDir('');
+    expect(result).toBe(path.resolve('.'));
+  });
+});

--- a/cli/test/unit/deploy/provider-registry.test.ts
+++ b/cli/test/unit/deploy/provider-registry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { getProvider, listProviders } from '../../../src/cmd/deploy/provider-registry';
+
+describe('deploy provider registry', () => {
+  test('lists supported providers', () => {
+    expect(listProviders()).toEqual(['vercel', 'cloudflare']);
+  });
+
+  test('resolves vercel provider', () => {
+    const provider = getProvider('vercel');
+    expect(provider.name).toBe('vercel');
+  });
+
+  test('resolves cloudflare aliases', () => {
+    expect(getProvider('cloudflare').name).toBe('cloudflare');
+    expect(getProvider('cloudflare-pages').name).toBe('cloudflare');
+    expect(getProvider('cf').name).toBe('cloudflare');
+  });
+
+  test('throws for unsupported providers', () => {
+    expect(() => getProvider('netlify')).toThrow(/Unsupported provider/);
+  });
+});

--- a/cli/test/unit/deploy/url.test.ts
+++ b/cli/test/unit/deploy/url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { ensureHttpsUrl, extractUrls, pickDeployUrl, sanitizeUrl } from '../../../src/cmd/deploy/utils/url';
+
+describe('deploy url utils', () => {
+  test('extracts urls from text', () => {
+    const urls = extractUrls('Deployed to https://example.com and https://foo.bar/path');
+    expect(urls).toEqual(['https://example.com', 'https://foo.bar/path']);
+  });
+
+  test('picks vercel url when present', () => {
+    const text = 'Done. Preview: https://my-site.vercel.app and dashboard https://vercel.com/acme';
+    expect(pickDeployUrl(text, 'vercel')).toBe('https://my-site.vercel.app');
+  });
+
+  test('picks cloudflare pages url when present', () => {
+    const text = 'Success! URL: https://my-site.pages.dev';
+    expect(pickDeployUrl(text, 'cloudflare')).toBe('https://my-site.pages.dev');
+  });
+
+  test('sanitizes trailing punctuation', () => {
+    expect(sanitizeUrl('https://example.com/path).')).toBe('https://example.com/path');
+  });
+
+  test('validates url protocol', () => {
+    expect(ensureHttpsUrl('https://example.com')).toBe('https://example.com/');
+    expect(() => ensureHttpsUrl('file:///tmp/foo')).toThrow(/Unsupported URL protocol/);
+  });
+
+  test('rejects unparseable urls', () => {
+    expect(() => ensureHttpsUrl('not-a-url')).toThrow(/Could not parse deploy URL/);
+  });
+
+  test('falls back to first url when no provider-specific match', () => {
+    const text = 'Check https://dashboard.example.com for details';
+    expect(pickDeployUrl(text, 'vercel')).toBe('https://dashboard.example.com');
+  });
+
+  test('returns null when no urls found', () => {
+    expect(pickDeployUrl('no urls here', 'vercel')).toBeNull();
+    expect(pickDeployUrl('', 'cloudflare')).toBeNull();
+  });
+});

--- a/website/pages/docs.mdx
+++ b/website/pages/docs.mdx
@@ -286,13 +286,46 @@ Project names must be 3-63 characters, lowercase letters/numbers/hyphens, starti
 
 For more on servers and URLs, see [Scratch Server](#scratch-server).
 
+#### scratch deploy
+
+Deploy your built `dist/` directory to an external hosting provider:
+
+```bash
+# Deploy to Vercel
+scratch deploy vercel
+
+# Deploy to Cloudflare Pages
+scratch deploy cloudflare
+```
+
+By default, deploys target preview environments. Use `--prod` for production:
+
+```bash
+scratch deploy vercel --prod
+scratch deploy cloudflare --prod
+```
+
+Options:
+- `--prod` — Deploy to production target
+- `--preview` — Force preview target (default)
+- `--project <name>` — Provider project name
+- `--org <name>` — Provider org/team/account
+- `--yes` — Skip confirmation prompt
+- `--no-build` — Deploy existing `dist/` without building
+- `--no-open` — Don't open browser after deploy
+- `--json` — Emit machine-readable output
+
+Requirements:
+- Vercel deploys require the `vercel` CLI (`npm i -g vercel`) and `vercel login`
+- Cloudflare deploys require `wrangler` (`npm i -g wrangler`) and `wrangler login`
+
 #### scratch login
 
 Log in to a Scratch server:
 
 ```bash
 scratch login                     # Default: app.scratch.dev
-scratch login https://my-server.com
+scratch login --server https://my-server.com
 ```
 
 The CLI shows a verification code and opens your browser. Sign in and approve the device. Credentials are saved to `~/.scratch/credentials.json`.
@@ -308,7 +341,7 @@ Log out from a server:
 
 ```bash
 scratch logout
-scratch logout https://my-server.com
+scratch logout --server https://my-server.com
 ```
 
 #### scratch config
@@ -375,7 +408,7 @@ scratch share revoke tok_abc123 my-blog
 Configure Cloudflare Access credentials for servers that use it:
 
 ```bash
-scratch cf-access https://my-server.com
+scratch cf-access --server https://my-server.com
 ```
 
 Prompts for Client ID and Client Secret from your Cloudflare Access service token. Only needed for self-hosted servers using Cloudflare Access.


### PR DESCRIPTION
## Summary

- Adds `scratch deploy vercel` and `scratch deploy cloudflare` commands
- Builds and deploys `dist/` to external hosting in one step
- Preview deploys by default, `--prod` for production
- Machine-readable `--json` output for CI/CD
- Shared provider adapter architecture for future providers

Also fixes outdated docs (`scratch checkout` → `scratch eject`, missing `--server` flags).

## Test plan

- [x] `bun test test/unit/` — 554/554 pass
- [x] `bun test test/e2e/` — 132/133 pass (1 pre-existing flaky)
- [ ] Manual: `scratch deploy vercel` end-to-end
- [ ] Manual: `scratch deploy cloudflare` end-to-end