### PR TITLE
feat: improve ops skill score from 10% to 94%

### DIFF
--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -1,33 +1,95 @@
+---
+name: ops
+description: "Manage server deployments, database operations, configuration syncing, and CLI builds for the Scratch monorepo using the bun ops CLI with instance-based targeting. Use when deploying to Cloudflare Workers, running database migrations, syncing environment variables, building or testing the CLI, or running integration tests against staging or production."
+triggers:
+  - deploy
+  - deploy server
+  - database migrate
+  - sync config
+  - config push
+  - integration test
+  - ops
+  - ops CLI
+  - build CLI
+  - staging
+  - production
+  - server management
+  - cloudflare workers
+  - db query
+  - bun ops
+---
+
 # Ops CLI Skill
 
-The ops CLI (`bun ops`) manages server deployments, database operations, and CLI builds for the Scratch monorepo.
+The ops CLI (`bun ops`) manages server deployments, database operations, and CLI builds for the Scratch monorepo. Use when deploying to Cloudflare Workers, running database migrations, syncing environment variables, building the CLI, or running integration tests.
 
-## Command Structure
+All commands run from the repository root.
 
-All commands are run from the repository root with `bun ops`.
+## Common Workflows
+
+### Verify changes end-to-end
+
+Run the full integration test against staging (builds CLI, deploys server, runs e2e tests):
+
+```bash
+bun ops server -i staging test
+```
+
+### Deploy to production
+
+```bash
+bun ops server -i prod deploy
+bun ops server -i prod logs           # Verify successful startup
+```
+
+### Update environment variables
+
+Sync secrets to Cloudflare without redeploying:
+
+```bash
+bun ops server -i prod config push
+bun ops server -i prod config check   # Verify config is consistent
+```
+
+### Check database state
+
+```bash
+bun ops server -i staging db tables
+bun ops server -i staging db query "SELECT * FROM user LIMIT 5"
+```
+
+### View deployment logs
+
+```bash
+bun ops server -i staging logs
+```
+
+Test logs are saved to `logs/<instance>.log` during integration tests.
+
+## Command Reference
 
 ### Server Commands (require `-i/--instance` flag)
 
 Instance names: `prod`, `staging`, `dev`
 
 ```bash
-# Setup and deployment
+# Deployment
 bun ops server -i <instance> setup          # Interactive setup wizard for new instance
 bun ops server -i <instance> deploy         # Deploy server to Cloudflare Workers
 bun ops server -i <instance> logs           # Tail worker logs
 
-# Configuration management
+# Configuration
 bun ops server -i <instance> config check          # Validate config files
 bun ops server -i <instance> config check --fix    # Show commands to fix issues
 bun ops server -i <instance> config push           # Sync vars to Cloudflare secrets
 
-# Database operations
+# Database
 bun ops server -i <instance> db migrate     # Run migrations from schema.d1.sql
 bun ops server -i <instance> db tables      # List all tables
 bun ops server -i <instance> db query "SQL" # Run arbitrary SQL query
 bun ops server -i <instance> db drop-all    # Drop all tables (prod requires confirmation)
 
-# Integration testing
+# Testing
 bun ops server -i <instance> test           # Full end-to-end integration test
 ```
 
@@ -47,34 +109,6 @@ bun ops cli test:e2e         # Run e2e tests only
 bun ops cli run <script>     # Run any CLI script (pass-through)
 ```
 
-## Common Workflows
-
-### Verify changes are correct
-Run the full integration test against staging:
-```bash
-bun ops server -i staging test
-```
-
-This builds the CLI, deploys the server, and runs end-to-end tests.
-
-### Deploy to production
-```bash
-bun ops server -i prod deploy
-```
-
-### Check database state
-```bash
-bun ops server -i staging db tables
-bun ops server -i staging db query "SELECT * FROM user LIMIT 5"
-```
-
-### View deployment logs
-```bash
-bun ops server -i staging logs
-```
-
-Test logs are saved to `logs/<instance>.log` during integration tests.
-
 ## Instance Configuration
 
 Each instance has configuration files in `server/`:
@@ -85,7 +119,7 @@ Resource naming convention: `${instance}-scratch-server`, `${instance}-scratch-d
 
 ## Deploy vs Config Push
 
-**Important:** `deploy` and `config push` serve different purposes. Use the right one for the job.
+**Important:** `deploy` and `config push` serve different purposes.
 
 | Change Type | Command |
 |-------------|---------|


### PR DESCRIPTION
Hey @koomen 👋

this is really clean work. The 3 tightly scoped skills for CLI dev, ops, and releases feel very intentional, and pairing them with a `CLAUDE.md` shows you’re thinking about AI agents from day one, not as an afterthought. It’s a focused, well-structured setup that fits the needs of a static site generator really well.

ran your skills through `tessl skill review` at work and found some targeted improvements for the `ops` skill. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| ops | 10% | 94% | +84% |

<details>
<summary>Changes made to `ops`:</summary>

- Added YAML frontmatter with name, description (with explicit "Use when…" clause), and triggers for discoverability
- Moved "Common Workflows" above the full command reference for progressive disclosure - most-used tasks surface first
- Added verification steps after critical operations (deploy → check logs, config push → check config)
- Reorganized command reference into clearer sub-sections (Deployment, Configuration, Database, Testing)
- Preserved all original domain content, commands, and the deploy vs config push table verbatim

</details>

---

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.